### PR TITLE
Use post-process

### DIFF
--- a/ox-pandoc.el
+++ b/ox-pandoc.el
@@ -297,7 +297,7 @@ Use the :pandoc-output-format propery to specify an output
 format, a symbol corresponding with a valid pandoc output format
 name. If not specified, markdown will be used."
   (let* ((output-format (plist-get plist :pandoc-output-format))
-         (file-ext (org-pandoc-output-file-extension output-format nil pub-dir))
+         (file-ext (org-pandoc-output-file-extension output-format))
          (process (org-pandoc-process-function output-format)))
     (org-publish-attachment
      plist

--- a/ox-pandoc.el
+++ b/ox-pandoc.el
@@ -47,13 +47,6 @@
   :version "24.4"
   :package-version '(Org . "8.0"))
 
-(defcustom org-pandoc-process-after-export t
-  "Run pandoc to process the file after exporting it?"
-  :group 'org-export-pandoc
-  :type '(choice
-          (const :tag "Yes" t)
-          (const :tag "No" nil)))
-
 (defcustom org-pandoc-command "pandoc"
   "Command to run pandoc."
   :group 'org-export-pandoc
@@ -66,43 +59,78 @@ to expand the stack here."
   :group 'org-export-pandoc
   :type 'string)
 
-(defcustom org-pandoc-output-format 'epub
-  "Default output format for pandoc conversion."
-  :group 'org-export-pandoc
-  :type 'symbol)
-
-(defcustom org-pandoc-output-standalone t
-  "Should output be a single standalone file or not?"
-  :group 'org-export-pandoc
-  :type 'boolean)
-
-(defcustom org-pandoc-epub-rights nil
-  "Copyright/license statement to include in EPUB metadata."
-  :group 'org-export-pandoc
-  :type 'string)
-
-(defcustom org-pandoc-epub-stylesheet nil
-  "Stylesheet to apply to EPUB files."
-  :group 'org-export-pandoc
-  :type 'string)
-
-(defvar org-pandoc---epub-metadata nil)
-(defvar org-pandoc---epub-cover-filename nil)
-(defvar org-pandoc---epub-stylesheet-filename nil)
-(defvar org-pandoc---command-options nil)
+(defvar org-pandoc---info nil)
 
 (org-export-define-derived-backend 'pandoc 'md
   :menu-entry
   '(?p "Export with Pandoc"
        ((?P "Markdown to buffer"
             (lambda (a s v b) (org-pandoc-export-as-pandoc a s v)))
-        (?p "To file"
-            (lambda (a s v b) (org-pandoc-export-to-pandoc a s v)))))
+        (?a "To asciidoc"
+            (lambda (a s v b) (org-pandoc-export-to-file 'asciidoc a s v)))
+        (?b "To beamer"
+            (lambda (a s v b) (org-pandoc-export-to-file 'beamer a s v)))
+        (?c "To context"
+            (lambda (a s v b) (org-pandoc-export-to-file 'context a s v)))
+        (?d "To docbook"
+            (lambda (a s v b) (org-pandoc-export-to-file 'docbook a s v)))
+        (?D "To docx"
+            (lambda (a s v b) (org-pandoc-export-to-file 'docx a s v)))
+        (?\C-d "To dzslides"
+             (lambda (a s v b) (org-pandoc-export-to-file 'dzslides a s v)))
+        (?e "To epub"
+            (lambda (a s v b) (org-pandoc-export-to-file 'epub a s v)))
+        (?E "To epub3"
+            (lambda (a s v b) (org-pandoc-export-to-file 'epub3 a s v)))
+        (?f "To fb2"
+             (lambda (a s v b) (org-pandoc-export-to-file 'fb2 a s v)))
+        (?h "To html"
+            (lambda (a s v b) (org-pandoc-export-to-file 'html a s v)))
+        (?5 "To html5"
+            (lambda (a s v b) (org-pandoc-export-to-file 'html5 a s v)))
+        (?j "To json"
+            (lambda (a s v b) (org-pandoc-export-to-file 'json a s v)))
+        (?l "To latex"
+            (lambda (a s v b) (org-pandoc-export-to-file 'latex a s v)))
+        (?m "To man"
+            (lambda (a s v b) (org-pandoc-export-to-file 'man a s v)))
+        (?p "To markdown"
+            (lambda (a s v b) (org-pandoc-export-to-file 'markdown a s v)))
+        (?n "To native"
+            (lambda (a s v b) (org-pandoc-export-to-file 'native a s v)))
+        (?O "To odt"
+            (lambda (a s v b) (org-pandoc-export-to-file 'odt a s v)))
+        (?\C-o "To opendocument"
+            (lambda (a s v b) (org-pandoc-export-to-file 'opendocument a s v)))
+        (?M "To opml"
+             (lambda (a s v b) (org-pandoc-export-to-file 'opml a s v)))
+        (?o "To org"
+            (lambda (a s v b) (org-pandoc-export-to-file 'org a s v)))
+        (?p "To pdf"
+            (lambda (a s v b) (org-pandoc-export-to-file 'pdf* a s v)))
+        (?\C-p "To plain"
+            (lambda (a s v b) (org-pandoc-export-to-file 'plain a s v)))
+        (?\C-r "To revealjs"
+             (lambda (a s v b) (org-pandoc-export-to-file 'revealjs a s v)))
+        (?r "To rst"
+            (lambda (a s v b) (org-pandoc-export-to-file 'rst a s v)))
+        (?R "To rtf"
+            (lambda (a s v b) (org-pandoc-export-to-file 'rtf a s v)))
+        (?s "To s5"
+            (lambda (a s v b) (org-pandoc-export-to-file 's5 a s v)))
+        (?S "To slideous"
+            (lambda (a s v b) (org-pandoc-export-to-file 'slideous a s v)))
+        (?\C-s "To slidy"
+               (lambda (a s v b) (org-pandoc-export-to-file 'slidy a s v)))
+        (?T "To texinfo"
+            (lambda (a s v b) (org-pandoc-export-to-file 'texinfo a s v)))
+        (?t "To textile"
+            (lambda (a s v b) (org-pandoc-export-to-file 'textile a s v)))))
   :translate-alist '((template . org-pandoc-template))
-  :options-alist '((:epub-rights "EPUB_RIGHTS" nil org-pandoc-epub-rights t)
+  :options-alist '((:epub-rights "EPUB_RIGHTS" nil nil t)
                    (:epub-cover "EPUB_COVER" nil nil t)
-                   (:epub-stylesheet "EPUB_STYLESHEET" nil org-pandoc-epub-stylesheet t)
-                   (:pandoc-options "PANDOC_OPTIONS" nil org-pandoc-extra-options 'space)
+                   (:epub-stylesheet "EPUB_STYLESHEET" nil nil t)
+                   (:pandoc-options "PANDOC_OPTIONS" nil nil 'space)
                    ))
 
 ;; Some simple XML escaping code.  I'm surprised this isn't
@@ -131,31 +159,9 @@ to expand the stack here."
 (defun org-pandoc-template (contents info)
   (let ((title (plist-get info :title))
         (author (plist-get info :author))
-        (email (plist-get info :email))
-        (description (plist-get info :description))
-        (keywords (plist-get info :keywords))
-        (date (org-export-get-date info "%Y-%m-%d"))
-        (rights (plist-get info :epub-rights)))
-    ;; Since the info alist isn't available after the export, build the metadata
-    ;; now and put it in a buffer local variable. 
-    (if (or (eq org-pandoc-output-format 'epub)
-            (eq org-pandoc-output-format 'epub3))
-        (let ((xml (concat
-                    (when description
-                      (format "<dc:description>%s</dc:description>\n" (org-pandoc-escape-xml description)))
-                    (format "<dc:rights>%s</dc:rights>\n"
-                            (org-pandoc-escape-xml (or rights
-                                                       (org-pandoc-make-copyright-string (org-export-data author info) (org-export-data email info)))))
-                    (when keywords
-                      (format "<dc:subject>%s</dc:subject>\n" (org-pandoc-escape-xml keywords))))))
-          (setq org-pandoc---epub-stylesheet-filename (plist-get info :epub-stylesheet))
-          (setq org-pandoc---epub-metadata xml)
-          (setq org-pandoc---epub-cover-filename (plist-get info :epub-cover)))
-      (progn
-        (setq org-pandoc---epub-stylesheet-filename nil)
-        (setq org-pandoc---epub-metadata nil)
-        (setq org-pandoc---epub-cover-filename nil)))
-    (setq org-pandoc---command-options (plist-get info :pandoc-options))
+        (date (org-export-get-date info "%Y-%m-%d")))
+    ;; Store info for later reference.
+    (setq org-pandoc---info info)
     (concat (format "%% %s\n" (org-export-data title info))
             (when (and (plist-get info :with-author)
                        author)
@@ -165,63 +171,137 @@ to expand the stack here."
             "\n"
             contents)))
 
-(defun org-pandoc-export-as-pandoc (&optional async subtreep visible-only)
-  (interactive)
-  (if async
-      (org-export-async-start
-          (lambda (output)
-            (with-current-buffer (get-buffer-create "*Org Pandoc Export*")
-              (erase-buffer)
-              (insert output)
-              (goto-char (point-min))
-              (markdown-mode)
-              (org-export-add-to-stack (current-buffer) 'pandoc)))
-        `(org-export-as 'pandoc ,subtreep ,visible-only))
-    (let ((outbuf (org-export-to-buffer 'pandoc "*Org Pandoc Export*" subtreep visible-only)))
-      (with-current-buffer outbuf (markdown-mode))
-      (when org-export-show-temporary-export-buffer
-        (switch-to-buffer-other-window outbuf)))))
-
 (defun org-pandoc-run-pandoc (filename outfilename output-format &optional options)
   (let* ((args (list "-t" (symbol-name output-format)
+                     "-f" "markdown"
                      "-o" outfilename
                      options
+                     org-pandoc-extra-options
                      filename))
          (command (concat org-pandoc-command " " (mapconcat 'identity args " "))))
     (message "Running pandoc as: %s" command)
     (message "Ran pandoc: %s" (shell-command-to-string command))))
 
-(defun org-pandoc-export-to-file (&optional outfile subtreep visible-only)
-  (let ((metadata-file (make-temp-file "org-pandoc" nil ".xml"))
-        (pandoc-output (concat (file-name-base outfile) "." (symbol-name org-pandoc-output-format))))
-    (org-export-to-file 'pandoc outfile subtreep visible-only)
-    ;; I really hate passing info back with global variables, but I don't know how
-    ;; else to do it.  Can't use a buffer local variable because the current buffer
-    ;; is different in this function than when the export is actually running and
-    ;; we have access to the info plist.
-    (let ((options (concat (when org-pandoc-output-standalone " -s")
-                           (when org-pandoc---epub-cover-filename
-                             (format " --epub-cover-image=%s" org-pandoc---epub-cover-filename))
-                           (when org-pandoc---epub-stylesheet-filename
-                             (format " --epub-stylesheet=%s" org-pandoc---epub-stylesheet-filename))
-                           (when org-pandoc---command-options
-                             (concat " " org-pandoc---command-options)))))
-      (when org-pandoc---epub-metadata
-        (with-temp-file metadata-file
-          (insert org-pandoc---epub-metadata))
-        (setq options (concat options " --epub-metadata=" metadata-file)))
-      (org-pandoc-run-pandoc outfile pandoc-output org-pandoc-output-format options))
-    (delete-file metadata-file)
-    ))
+(defun org-pandoc-make-epub-metadata-file (info)
+  (let* ((description (plist-get info :description))
+         (author (plist-get info :author))
+         (email (plist-get info :email))
+         (rights (org-pandoc-escape-xml
+                  (or (plist-get info :epub-rights)
+                      (org-pandoc-make-copyright-string
+                       (org-export-data author info) 
+                       (org-export-data email info)))))
+        (keywords (plist-get info :keywords))
+        (metadata-file (make-temp-file "org-pandoc" nil ".xml")))
+    (with-temp-file metadata-file
+      (insert (concat
+               (if description
+                   (format "<dc:description>%s</dc:description>\n"
+                           (org-pandoc-escape-xml description)))
+               "<dc:rights>"
+               rights
+               "</dc:rights>\n"
+               (if keywords
+                 (format "<dc:subject>%s</dc:subject>\n" (org-pandoc-escape-xml keywords))))))
+    metadata-file))
 
-(defun org-pandoc-export-to-pandoc (&optional async subtreep visible-only)
+(defun org-pandoc-process-function (&optional output-format subtreep ext-plist)
+  "Return a function that will process a file in place with
+pandoc. OUTPUT-FORMAT is a symbol."
+  (lexical-let () ; capture output-format
+    (lambda (file)
+      (if (and (not (null output-format))
+               (not (eq output-format 'markdown)))
+          (let* ((info org-pandoc---info)
+                 (epub-cover (plist-get info :epub-cover))
+                 (epub-stylesheet (plist-get info :epub-stylesheet))
+                 (pandoc-options (plist-get info :pandoc-options))
+                 (options (concat " -s"
+                                  (if (or (eq output-format 'epub)
+                                          (eq output-format 'epub3))
+                                      (concat 
+                                       (if epub-cover
+                                           (format " --epub-cover-image=%s" epub-cover))))
+                                  (if epub-stylesheet
+                                      (format " --epub-stylesheet=%s" epub-stylesheet))
+                                  " --epub-metadata=" 
+                                  (org-pandoc-make-epub-metadata-file info)
+                                  (if pandoc-options
+                                      (concat " " pandoc-options)))))
+            (org-pandoc-run-pandoc file file output-format options)))
+      file)))
+
+(defun org-pandoc-output-file-extension (output-format)
+  "Return file extension for OUTPUT-FORMAT."
+  (case output-format
+    (asciidoc ".asciidoc")
+    (beamer ".latex")
+    (context ".context")
+    (docbook ".db")
+    (docx ".docx")
+    (dzslides ".dzslides.html")
+    (epub ".epub")
+    (epub3 ".epub3")
+    (fb2 ".fb2")
+    (html ".html")
+    (html5 ".html5")
+    (json ".json")
+    (latex ".latex")
+    (man ".man")
+    (markdown ".md")
+    (markdown_github ".github.md")
+    (markdown_mmd ".mmd.md")
+    (markdown_phpextra ".phpextra.md")
+    (markdown_strict ".strict.md")
+    (mediawiki ".mediawiki")
+    (native ".native")
+    (odt ".odt")
+    (opendocument ".xml")
+    (opml ".opml")
+    (org ".pandoc_org")
+    (plain ".txt")
+    (revealjs ".revealjs.html")
+    (rst ".rst")
+    (rtf ".rtf")
+    (s5 ".s5.html")
+    (slideous ".slideous.html")
+    (slidy ".slidy.html")
+    (texinfo ".texi")
+    (textile ".textile")
+    (t (error "No format extension found for %s" (symbol-name format)))))
+
+(defun org-pandoc-export-output-file-name (output-format &optional subtreep pub-dir)
+  "Makes an output file name for pandoc."
+  (org-export-output-file-name
+   (org-pandoc-output-file-extension output-format)
+   subtreep 
+   pub-dir))
+
+(defun org-pandoc-export-to-file
+  (&optional output-format filename async subtreep visible-only body-only ext-plist)
+  "Export current buffer to file.
+
+If optional argument OUTPUT-FORMAT (a symbol) is given, will
+export to that format. Otherwise will export to Pandoc compatible
+markdown without post-processing."
   (interactive)
-  (let ((outfile (org-export-output-file-name ".md" subtreep)))
-    (if async
-        (org-export-async-start
-            (lambda (f) (org-export-add-to-stack f 'pandoc))
-          `(expand-file-name
-            (org-pandoc-export-to-file ,outfile ,subtreep ,visible-only)))
-      (org-pandoc-export-to-file outfile subtreep visible-only))))
+  (org-export-to-file 'pandoc
+      (org-pandoc-export-output-file-name output-format subtreep)
+    async subtreep visible-only body-only ext-plist
+    (org-pandoc-process-function output-format subtreep ext-plist)))
+
+(defun org-pandoc-publish-to (plist filename pub-dir)
+  "Publish an org file via pandoc.
+
+Use the :pandoc-output-format propery to specify an output
+format, a symbol corresponding with a valid pandoc output format
+name. If not specified, markdown will be used."
+  (let* ((output-format (plist-get plist :pandoc-output-format))
+         (file-ext (org-pandoc-output-file-extension output-format nil pub-dir))
+         (process (org-pandoc-process-function output-format)))
+    (org-publish-attachment
+     plist
+     (funcall process (org-publish-org-to 'pandoc filename file-ext plist pub-dir))
+     pub-dir)))
 
 (provide 'ox-pandoc)

--- a/testing/ox-pandoc-test.el
+++ b/testing/ox-pandoc-test.el
@@ -1,0 +1,30 @@
+(ert-deftest org-pandoc-test-export ()
+  (save-excursion
+    (find-file "test.org")
+    (loop
+     for format in '(asciidoc beamer context docbook docx
+                              dzslides epub epub3 fb2 html html5
+                              json latex man markdown
+                              markdown_github markdown_mmd
+                              markdown_phpextra markdown_strict
+                              mediawiki native odt opendocument
+                              opml org plain revealjs rst rtf s5
+                              slideous slidy texinfo textile)
+     do
+     (let ((out-file (format "test%s" (org-pandoc-output-file-extension format))))
+       (should-not (string= out-file "test.org"))
+       (if (not (string= out-file "test.org"))
+           (progn
+             (org-pandoc-export-to-file format)
+             (should (file-exists-p out-file))
+             (delete-file out-file)))))))
+
+(ert-deftest org-pandoc-test-publish ()
+  (org-publish 
+      '("test-project"
+        :base-directory "."
+        :publishing-directory "/tmp/publish-test"
+        :pandoc-output-format html5
+        :publishing-function org-pandoc-publish-to)
+      t)
+  (should (file-exists-p "/tmp/publish-test/test.html5")))

--- a/testing/test.org
+++ b/testing/test.org
@@ -1,0 +1,32 @@
+#+TITLE: Test file
+#+KEYWORDS: cat1 cat2
+#+AUTHOR: Jane Doe
+#+DATE : 2014-01-21
+#+OPTIONS: toc:t
+* Test org
+‹In the 1920s [1920-01-01], government switch from promoting railroads to promoting
+automobiles. By the end of the 1930s [1939-01-01], gasoline for autos dominated the
+oil market.› [@sabin:2000petroleum, p. 13]
+
+#+BEGIN_SRC calc
+1 + 1
+#+END_SRC
+
+#+RESULTS:
+: 2
+
+
+| Name  | Phone | Age |
+|-------+-------+-----|
+| Peter |  1234 |  17 |
+| Anna  |  4321 |  25 |
+
+** list
+- uno
+- dos
+- tres
+
+** ordered list
+1. uno
+2. due
+3. tre


### PR DESCRIPTION
This is my second try at rewriting to use the post-process feature of org-export to process with pandoc. Cleaner than the last one. Also uses org-publish-attachment to implement org-publish. Adds many output formats to the export menu. Also rewrites the epub metadata writing to be (hopefully) a little simpler. Also, a few tests.
